### PR TITLE
fix: replace in-memory rate limiting with MongoDB TTL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    turbo: false, // 🚫 HARD DISABLE TURBOPACK
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Replaced in-memory rate limiting with MongoDB-backed TTL
- Prevents rate limit bypass on server restart
- Uses MongoDB TTL index for automatic expiry
